### PR TITLE
Update README to include instructions for running the app locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,30 @@ We need to effectively communicate that Techtonica and its students are worth su
 ### How
 There should be a good understanding of how the program works with vetting, training, mentoring, and hiring.
 
-## SITE DEPENDENCIES
+## Getting Started
 ----------------------
 
-Python 2.7 (Recomended)
+This app uses Python 2.7; please stick to this version.
 
-Python Packages
-*  [Flask](http://flask.pocoo.org/docs/ "Flask Documentation")
+#### Running Locally
+
+It is recommended you use a Virtual Environment tool to keep dependencies required by different projects separate. Learn more about Virtual Environments and Python [here](http://docs.python-guide.org/en/latest/dev/virtualenvs/)
+
+Install the project dependencies. In the project root run:
+
+```
+$ pip install -r requirements.txt
+```
+
+Start the application's server:
+
+```
+$ FLASK_APP=main_site.py flask run
+```
+
+Browse to `localhost:5000`
+
+
 
 ## DEPLOYMENT / UPDATE NOTES
 -----------------------------
@@ -24,10 +41,15 @@ Python Packages
 8-25-2016 19:00 CST
 
 Installed Python 2.7.12
+
 Submitted a ticket to Python so that the symlink would would work correctly when installed from source.
-Installed Virtialenv
+
+Installed Virtualenv
+
 Installed Flask
+
 Installed Pip
+
 Installed Flup
 
 Tested the site on techtonica.org/test/ for basic functionality.
@@ -41,5 +63,7 @@ Article used to get through the BlueHost wierdness linked below:
 ------------------------
 
 Log in via SSH using your SSH key
-Navigate to your pbulic html folder using: cd public_html
-Submit pull request from github  using: git pull
+
+Navigate to your public html folder using: cd public_html
+
+Submit pull request from github using: git pull


### PR DESCRIPTION
While working on the app yesterday, I made some notes on how I got everything running locally. 

I'm making the assumption that the reader has Python 2.7.9+ installed, in which case Pip comes packaged with the binary installers. If we don't want to make this assumption, I can make it clear that the reader should check if they have Pip with:

```
$ pip --version
```

And if not, instruct the reader to install (linking to https://pip.pypa.io/en/stable/installing/).

I also cleanedup some of the markdown in the DEPLOYMENT / UPDATE NOTES and UPDATING THE SITE sections to add some newlines for legibility. 

