### PR TITLE
Add additional margin to main content div so navbar doesn't overlap

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -202,7 +202,7 @@ button {
   padding-left: 1rem; }
 
 .main-content {
-  margin-top: 4rem; }
+  margin-top: 8rem; }
 
 .main-header {
   -webkit-background-size: cover;


### PR DESCRIPTION
This PR adds a quick fix for the About page from https://github.com/MichelleGlauser/techtonica/issues/21 by adding additional margin to the main content div so the navbar doesn't overlap. 

<img width="1419" alt="screen shot 2016-09-25 at 12 02 14 pm" src="https://cloud.githubusercontent.com/assets/6598185/18817563/45dade50-8318-11e6-9dd1-7333b206f381.png">

/cc @MichelleGlauser 
