### PR TITLE
Minor frontend fixes

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -7,7 +7,9 @@
 {% block content %}
   <div class="row row__center about-us">
     <div class="column hidden-med">
-      <img src="{{ url_for('static', filename='img/april-workshop-group-min.jpg') }}"  alt="techtonica logo shape" class="full-width-img">
+      <img src="{{ url_for('static', filename='img/april-workshop-group-min.jpg') }}"
+           alt="Fifteen participants, mostly women, gathered after a workshop."
+           class="full-width-img">
     </div>
     <div class="column">
       <h1 class="blue-h1">About Us</h1>

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,7 +34,7 @@
     <nav class="nav-bar banner-visible">
       <div class="nav-bar-inner">
         <a href="{{ url_for('render_home_page') }}" class="img-link">
-          <img src="{{ url_for('static', filename='img/techtonica_logo.png') }}" alt="Techtonica logo" class="logo">
+          <img src="{{ url_for('static', filename='img/techtonica_logo.png') }}" alt="Techtonica" class="logo">
         </a>
         <button class="lines-button hidden-lg" type="button" aria-label="Toggle Navigation">
           <span class="lines"></span>

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,7 +8,7 @@
       {% block title %}
       {% endblock title %}
     </title>
-    <meta name="description" content="Free tech training followed by job placement at tech companies for local, low-income women and non-binary adults." />
+    <meta name="description" content="We partner with tech companies to offer free tech training, living and childcare stipends, and job placement to low-income women and non-binary adults." />
     <meta name="keywords" content="Techtonica, coding school for women, coding academy, learn how to code, programming courses, low income, free tech training, coding, women's empowerment, education for women, LGBT, LGBTQIA+, non-binary, non-binary adults, genderqueer adults, adult education, vocational training, tech jobs, San Francisco, sf, software engineering, learn to code, software developer school, Michelle Glauser" />
     <meta property="og:title" content="Techtonica"/>
     <meta property="og:description" content="Tuition-free tech training and job placement at sponsoring companies for low-income women and non-binary adults."/>

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,9 +34,9 @@
     <nav class="nav-bar banner-visible">
       <div class="nav-bar-inner">
         <a href="{{ url_for('render_home_page') }}" class="img-link">
-          <img src="{{ url_for('static', filename='img/techtonica_logo.png') }}" alt="Techtonica logo"class="logo">
+          <img src="{{ url_for('static', filename='img/techtonica_logo.png') }}" alt="Techtonica logo" class="logo">
         </a>
-        <button class="lines-button hidden-lg" type="button" role="button" aria-label="Toggle Navigation">
+        <button class="lines-button hidden-lg" type="button" aria-label="Toggle Navigation">
           <span class="lines"></span>
         </button>
           <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=JK79ZYMRLEWDA" class="donate nav-link" target="_blank">Donate</a>

--- a/templates/careers.html
+++ b/templates/careers.html
@@ -7,7 +7,9 @@
 {% block content %}
   <div class="row row__center about-us">
     <div class="column hidden-med">
-      <img src="{{ url_for('static', filename='img/library-lab-workshop-2-min.jpg') }}"  alt="techtonica logo shape" class="fixed-img">
+      <img src="{{ url_for('static', filename='img/library-lab-workshop-2-min.jpg') }}"
+           alt="A teacher points to a screen in front of a class of workshop participants." 
+           class="fixed-img">
     </div>
     <div class="column">
       <h1 class="blue-h1">Join our team!</h1>

--- a/templates/home.html
+++ b/templates/home.html
@@ -58,7 +58,7 @@
           <p class="justify">
             <ul>
               <li>Encourage your company to <a href="https://goo.gl/forms/Q88hao4ApxVFl76N2" class="hover-link target="_blank">sign up to sponsor and hire students</a>.</li>
-              <li><a href="https://goo.gl/forms/jgD3BWCEg5RN8XwN2" class="hover-link target="_blank">Sign up to volunteer</a>.</li>
+              <li><a href="https://goo.gl/forms/jgD3BWCEg5RN8XwN2" class="hover-link" target="_blank">Sign up to volunteer</a>.</li>
               <li>Offer your space for the first six-month class in San Francisco.</li>
               <li><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=JK79ZYMRLEWDA" class="hover-link target="_blank">Donate</a> (donations are tax-deductible and you can sign up to donate monthly).</li>
             </ul>
@@ -73,20 +73,61 @@
           <h1 class="blue-h1">Supporters</h1>
           <div class="row">
             <div class="column centered">
-              <img src="{{ url_for('static', filename='img/sfpl-logo.jpg') }}" alt="san francisco public library" class="twenty-percent-width min-width-250 margin-25">
-              <img src="{{ url_for('static', filename='img/rackspace-startups-logo.png') }}" alt="rackspace" class="twenty-percent-width min-width-250 margin-25">
-              <img src="{{ url_for('static', filename='img/st-anthonys.jpg') }}" alt="st. anthonys" class="twenty-percent-width min-width-250 margin-25">
-              <img src="{{ url_for('static', filename='img/zendesk-logo.jpg') }}" alt="zendesk" class="twenty-percent-width min-width-250 margin-25">
-              <img src="{{ url_for('static', filename='img/python-software-foundation-logo.jpg') }}" alt="python" class="twenty-percent-width min-width-250 margin-25">
-              <img src="{{ url_for('static', filename='img/kapor-center-for-social-impact-logo.jpg') }}" alt="kapor" class="twenty-percent-width min-width-250 margin-25">
-              <img src="{{ url_for('static', filename='img/scienceexchange_logo.png') }}" alt="science exchange" class="twenty-percent-width min-width-250 margin-25">
-              <a href="https://github.com/gsong"><img src="{{ url_for('static', filename='img/George-Song.png') }}" alt="george-song" class="twenty-percent-width min-width-250 margin-25">
+              <a href="http://sfpl.org/" target="_blank">
+                  <img src="{{ url_for('static', filename='img/sfpl-logo.jpg') }}"
+                       alt="san francisco public library"
+                       class="twenty-percent-width min-width-250 margin-25">
               </a>
-              <a href="https://www.beezwax.net"><img src="{{ url_for('static', filename='img/beezwax-logo.png')}}" alt="beezwax"class="twenty-percent-width min-width-250 margin-25">
+              <a href="https://blog.rackspace.com/the-rackspace-startup-program" target="_blank">
+                  <img src="{{ url_for('static', filename='img/rackspace-startups-logo.png') }}"
+                       alt="rackspace"
+                       class="twenty-percent-width min-width-250 margin-25">
               </a>
-              <a href="https://www.linkedin.com/in/vwfchan/"><img src="{{ url_for('static', filename='img/Vivien-Chan.png') }}" alt="vivian-chan" class="twenty-percent-width min-width-250 margin-25">
+              <a href="https://www.stanthonysf.org/" target="_blank">
+                  <img src="{{ url_for('static', filename='img/st-anthonys.jpg') }}"
+                       alt="st. anthonys"
+                       class="twenty-percent-width min-width-250 margin-25">
               </a>
-              <img src="{{ url_for('static', filename='img/bridge-at-main.jpg') }}" alt="bridge at main" class="twenty-percent-width min-width-250 margin-25">
+              <a href="https://www.zendesk.com/" target="_blank">
+                  <img src="{{ url_for('static', filename='img/zendesk-logo.jpg') }}"
+                       alt="zendesk"
+                       class="twenty-percent-width min-width-250 margin-25">
+              </a>
+              <a href="https://www.python.org/psf/" target="_blank">
+                  <img src="{{ url_for('static', filename='img/python-software-foundation-logo.jpg') }}"
+                       alt="python"
+                       class="twenty-percent-width min-width-250 margin-25">
+              </a>
+              <a href="http://www.kaporcenter.org/" target="_blank">
+                  <img src="{{ url_for('static', filename='img/kapor-center-for-social-impact-logo.jpg') }}"
+                       alt="kapor"
+                       class="twenty-percent-width min-width-250 margin-25">
+              </a>
+              <a href="https://www.scienceexchange.com/" target="_blank">
+                  <img src="{{ url_for('static', filename='img/scienceexchange_logo.png') }}"
+                       alt="science exchange"
+                       class="twenty-percent-width min-width-250 margin-25">
+              </a>
+              <a href="https://github.com/gsong" target="_blank">
+                  <img src="{{ url_for('static', filename='img/George-Song.png') }}"
+                       alt="george-song"
+                       class="twenty-percent-width min-width-250 margin-25">
+              </a>
+              <a href="https://www.beezwax.net" target="_blank">
+                  <img src="{{ url_for('static', filename='img/beezwax-logo.png')}}"
+                       alt="beezwax"
+                       class="twenty-percent-width min-width-250 margin-25">
+              </a>
+              <a href="https://www.linkedin.com/in/vwfchan/" target="_blank">
+                  <img src="{{ url_for('static', filename='img/Vivien-Chan.png') }}"
+                       alt="vivian-chan"
+                       class="twenty-percent-width min-width-250 margin-25">
+              </a>
+              <a href="http://sfpl.org/?pg=0200006301" target="_blank">
+                  <img src="{{ url_for('static', filename='img/bridge-at-main.jpg') }}"
+                       alt="bridge at main"
+                       class="twenty-percent-width min-width-250 margin-25">
+              </a>
             </div>
           </div>
         </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -33,20 +33,23 @@
         </div>
       </div>
       <div class="row row__baseline how-it-works" id="howitworks">
-        <div class="column column-med centered">
-          <img src="{{ url_for('static', filename='img/lightbulb.png') }}" alt="lightbulb icon">
-          <h3>Vetting</h3>
-          <p>Techtonica conducts free intro workshops with local organizations and labs. We ask the most engaged, understanding, collaborative, resilient, and responsible students to complete challenges and teach before we invite them to apply for the full-time program.</p>
-        </div>
-        <div class="column column-med centered">
-          <img src="{{ url_for('static', filename='img/conversation.png') }}" alt="pencil icon">
-          <h3>Partner Companies</h3>
-          <p>Partner companies sponsor the training and provide mentors for the students. They have a say in the curriculum and receive inclusion training in preparation for employing one of their top-rated students at the end of the program. The sponsorship is tax-deductible.</p>
-        </div>
-        <div class="column column-med centered">
-          <img src="{{ url_for('static', filename='img/chalkboard.jpg') }}" alt="conversation bubbles icon">
-          <h3>Training</h3>
-          <p>Accepted students receive living stipends, childcare if needed, and six months of full-time training that includes laptops, lectures, building assignments, projects, and experienced guidance and feedback. Upon completion of the program, they are placed with a partner company.</p>
+        <h1 class="blue-h1">How it Works</h1>
+        <div class="row">
+            <div class="column column-med centered">
+              <img src="{{ url_for('static', filename='img/lightbulb.png') }}" alt="lightbulb icon">
+              <h3>Vetting</h3>
+              <p>Techtonica conducts free intro workshops with local organizations and labs. We ask the most engaged, understanding, collaborative, resilient, and responsible students to complete challenges and teach before we invite them to apply for the full-time program.</p>
+            </div>
+            <div class="column column-med centered">
+              <img src="{{ url_for('static', filename='img/conversation.png') }}" alt="pencil icon">
+              <h3>Partner Companies</h3>
+              <p>Partner companies sponsor the training and provide mentors for the students. They have a say in the curriculum and receive inclusion training in preparation for employing one of their top-rated students at the end of the program. The sponsorship is tax-deductible.</p>
+            </div>
+            <div class="column column-med centered">
+              <img src="{{ url_for('static', filename='img/chalkboard.jpg') }}" alt="conversation bubbles icon">
+              <h3>Training</h3>
+              <p>Accepted students receive living stipends, childcare if needed, and six months of full-time training that includes laptops, lectures, building assignments, projects, and experienced guidance and feedback. Upon completion of the program, they are placed with a partner company.</p>
+            </div>
         </div>
       </div>
       <div class="row row__center blue-background howtohelp">
@@ -67,9 +70,7 @@
         </div>
       </div>
       <div class="row row__center our-supporters" id="supporters">
-        <div class="column">
-          <h1 class="blue-h1">Supporters</a></h1>
-        </div>
+          <h1 class="blue-h1">Supporters</h1>
           <div class="row">
             <div class="column centered">
               <img src="{{ url_for('static', filename='img/sfpl-logo.jpg') }}" alt="san francisco public library" class="twenty-percent-width min-width-250 margin-25">

--- a/templates/home.html
+++ b/templates/home.html
@@ -9,7 +9,7 @@
       <div class="main-header">
         <div class="main-header__text blue-background">
           <h1>Techtonica</h1>
-          <p>Free tech training with living and childcare stipends and job placement for low-income women and non-binary adults. #BridgeTheTechGap</p>
+          <p>We partner with tech companies to offer free tech training, living and childcare stipends, and job placement to low-income women and non-binary adults. #BridgeTheTechGap</p>
         </div>
       </div>
       <div class="row row__center what-we-do" id="whatwedo">

--- a/templates/home.html
+++ b/templates/home.html
@@ -18,12 +18,12 @@
           <p class="justify">We provide tuition-free tech training to local, low-income women and non-binary adults and place them in positions at sponsoring companies that are ready to support more diverse teams. We don't discriminate by age.</p>
         </div>
         <div class="column">
-          <img src="{{ url_for('static', filename='img/michelle-teaching-small-min.jpg') }}" alt="two women working together at computer" class="full-width-img">
+          <img src="{{ url_for('static', filename='img/michelle-teaching-small-min.jpg') }}" alt="Two women sit at a computer, working together on some code." class="full-width-img">
         </div>
       </div>
       <div class="row row__center blue-background why-why" id="why">
         <div class="column">
-          <img src="{{ url_for('static', filename='img/tenderloin-sf-min.jpg') }}" alt="tenderloin neighborhood of san francisco" class="full-width-img">
+          <img src="{{ url_for('static', filename='img/tenderloin-sf-min.jpg') }}" alt="People on the streets of a run-down area of the Tenderloin neighborhood in San Francisco." class="full-width-img">
         </div>
         <div class="column">
           <h1>Why</h1>
@@ -36,17 +36,17 @@
         <h1 class="blue-h1">How it Works</h1>
         <div class="row">
             <div class="column column-med centered">
-              <img src="{{ url_for('static', filename='img/lightbulb.png') }}" alt="lightbulb icon">
+              <img src="{{ url_for('static', filename='img/lightbulb.png') }}" alt="" aria-hidden="true">
               <h3>Vetting</h3>
               <p>Techtonica conducts free intro workshops with local organizations and labs. We ask the most engaged, understanding, collaborative, resilient, and responsible students to complete challenges and teach before we invite them to apply for the full-time program.</p>
             </div>
             <div class="column column-med centered">
-              <img src="{{ url_for('static', filename='img/conversation.png') }}" alt="pencil icon">
+              <img src="{{ url_for('static', filename='img/conversation.png') }}" alt="" aria-hidden="true">
               <h3>Partner Companies</h3>
               <p>Partner companies sponsor the training and provide mentors for the students. They have a say in the curriculum and receive inclusion training in preparation for employing one of their top-rated students at the end of the program. The sponsorship is tax-deductible.</p>
             </div>
             <div class="column column-med centered">
-              <img src="{{ url_for('static', filename='img/chalkboard.jpg') }}" alt="conversation bubbles icon">
+              <img src="{{ url_for('static', filename='img/chalkboard.jpg') }}" alt="" aria-hidden="true">
               <h3>Training</h3>
               <p>Accepted students receive living stipends, childcare if needed, and six months of full-time training that includes laptops, lectures, building assignments, projects, and experienced guidance and feedback. Upon completion of the program, they are placed with a partner company.</p>
             </div>
@@ -66,7 +66,7 @@
           <p class="justify">To receive updates, please <a id="open-popup" class="hover-link newsletter pad-lv3 pad-tb0" href="#" onclick="openPopupForm(); return false;">sign up for our newsletter</a>.</p>
         </div>
         <div class="column">
-          <img src="{{ url_for('static', filename='img/ttl-rails-group-min.jpg') }}" alt="group of workshop attendees and volunteers" class="full-width-img">
+          <img src="{{ url_for('static', filename='img/ttl-rails-group-min.jpg') }}" alt="Twenty-five Techtonica attendees and volunteers standing together after a workshop." class="full-width-img">
         </div>
       </div>
       <div class="row row__center our-supporters" id="supporters">
@@ -75,57 +75,57 @@
             <div class="column centered">
               <a href="http://sfpl.org/" target="_blank">
                   <img src="{{ url_for('static', filename='img/sfpl-logo.jpg') }}"
-                       alt="san francisco public library"
+                       alt="San Francisco Public Library"
                        class="twenty-percent-width min-width-250 margin-25">
               </a>
               <a href="https://blog.rackspace.com/the-rackspace-startup-program" target="_blank">
                   <img src="{{ url_for('static', filename='img/rackspace-startups-logo.png') }}"
-                       alt="rackspace"
+                       alt="Rackspace Startups"
                        class="twenty-percent-width min-width-250 margin-25">
               </a>
               <a href="https://www.stanthonysf.org/" target="_blank">
                   <img src="{{ url_for('static', filename='img/st-anthonys.jpg') }}"
-                       alt="st. anthonys"
+                       alt="St. Anthony's: Hope Served Daily"
                        class="twenty-percent-width min-width-250 margin-25">
               </a>
               <a href="https://www.zendesk.com/" target="_blank">
                   <img src="{{ url_for('static', filename='img/zendesk-logo.jpg') }}"
-                       alt="zendesk"
+                       alt="Zendesk"
                        class="twenty-percent-width min-width-250 margin-25">
               </a>
               <a href="https://www.python.org/psf/" target="_blank">
                   <img src="{{ url_for('static', filename='img/python-software-foundation-logo.jpg') }}"
-                       alt="python"
+                       alt="Python Software Foundation"
                        class="twenty-percent-width min-width-250 margin-25">
               </a>
               <a href="http://www.kaporcenter.org/" target="_blank">
                   <img src="{{ url_for('static', filename='img/kapor-center-for-social-impact-logo.jpg') }}"
-                       alt="kapor"
+                       alt="Kapor Center for Social Impact"
                        class="twenty-percent-width min-width-250 margin-25">
               </a>
               <a href="https://www.scienceexchange.com/" target="_blank">
                   <img src="{{ url_for('static', filename='img/scienceexchange_logo.png') }}"
-                       alt="science exchange"
+                       alt="Science Exchange"
                        class="twenty-percent-width min-width-250 margin-25">
               </a>
               <a href="https://github.com/gsong" target="_blank">
                   <img src="{{ url_for('static', filename='img/George-Song.png') }}"
-                       alt="george-song"
+                       alt="George Song"
                        class="twenty-percent-width min-width-250 margin-25">
               </a>
               <a href="https://www.beezwax.net" target="_blank">
                   <img src="{{ url_for('static', filename='img/beezwax-logo.png')}}"
-                       alt="beezwax"
+                       alt="Beezwax"
                        class="twenty-percent-width min-width-250 margin-25">
               </a>
               <a href="https://www.linkedin.com/in/vwfchan/" target="_blank">
                   <img src="{{ url_for('static', filename='img/Vivien-Chan.png') }}"
-                       alt="vivian-chan"
+                       alt="Vivian Chan"
                        class="twenty-percent-width min-width-250 margin-25">
               </a>
               <a href="http://sfpl.org/?pg=0200006301" target="_blank">
                   <img src="{{ url_for('static', filename='img/bridge-at-main.jpg') }}"
-                       alt="bridge at main"
+                       alt="The Bridge at Main: Learning resources, classes, and people who can help."
                        class="twenty-percent-width min-width-250 margin-25">
               </a>
             </div>


### PR DESCRIPTION
A few notes:
- Rackspace.com is down, so I pointed the link to a Rackspace blog about Rackspace Startups
- Set alt tags for the “How it Works” section icons to empty strings because I'd consider them presentation-only (not really adding meaning)
- Added spacing to links for better readability
