### PR TITLE
insert back missing div tag

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -12,6 +12,7 @@
           <p>We partner with tech companies to offer free tech training and job placement to local women and non-binary femme adults in need. Our students have been selected—we just need you!</p>
           <h2><a href="{{ url_for('render_sponsor_page') }}" class="sponsor" id="orange-button" target="_blank">Sponsor a Techtonica student today!</a></h2>
 i      </div>
+      </div>
       <div class="row row__center what-we-do" id="whatwedo">
         <div class="column">
           <h1 class="blue-h1">What We Do</h1>


### PR DESCRIPTION
I merged recent changes on my local repo to work on the mail icon issue and noticed the home page broke. I reviewed past commits and noticed commit "Adjust language about what makes us different and tech companies" removed an extra div. When I put it back, the page looked normal again, so I am added this one-tag-change pull request in case no one fix it yet in their pull requests.